### PR TITLE
fix(perf): swap underscore for lodash

### DIFF
--- a/components/heat-map.js
+++ b/components/heat-map.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { NrqlQuery, Tooltip, Stack, StackItem } from 'nr1'
 import PropTypes from 'prop-types';
 import { groupBy, keys, sortBy } from 'lodash';

--- a/components/heat-map.js
+++ b/components/heat-map.js
@@ -1,6 +1,7 @@
+/* eslint-disable */
 import { NrqlQuery, Tooltip, Stack, StackItem } from 'nr1'
 import PropTypes from 'prop-types';
-import _ from 'underscore'
+import { groupBy, keys, sortBy } from 'lodash';
 import hsl from 'hsl-to-hex'
 
 /**
@@ -12,7 +13,7 @@ import hsl from 'hsl-to-hex'
  * ## Required packages
  * ```
  *    npm install hsl-to-hex
- *    npm install underscore
+ *    npm install lodash
  * ```
  * 
  * ## Examples
@@ -174,8 +175,8 @@ function SingleHeatmap(props) {
 function GroupedHeatMap(props) {
   const { data } = props
 
-  const groups = _.groupBy(data, 'group')
-  const groupNames = _.keys(groups).sort()
+  const groups = groupBy(data, 'group')
+  const groupNames = keys(groups).sort()
 
   return <div>
     {groupNames.map(groupName => {
@@ -210,7 +211,8 @@ function prepare({data, max}) {
     maxValue = Math.max(max, maxValue)
   }
 
-  data = _.sortBy(data, "name")
+  data = sortBy(data, "name");
+
   return {data, max: maxValue, isMultiFacet}
 }
 

--- a/nerdlets/container-explorer/container-explorer.js
+++ b/nerdlets/container-explorer/container-explorer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Grid, GridItem, Spinner } from 'nr1';
-import _ from 'underscore';
+import { sortBy } from 'lodash';
 
 import getCardinality from '../../lib/get-cardinality';
 import { timeRangeToNrql } from '@newrelic/nr1-community';
@@ -117,7 +117,7 @@ export default class ContainerExplorer extends React.Component {
       );
     });
 
-    this.setState({ groups: _.sortBy(groups, 'name') });
+    this.setState({ groups: sortBy(groups, 'name') });
   }
 
   selectContainer(containerId) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2070,11 +2070,6 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
     },
-    "underscore": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
-    },
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "lodash": "^4.17.15",
     "prop-types": "^15.6.2",
     "react": "^16.6.3",
-    "react-dom": "^16.6.3",
-    "underscore": "^1.9.1"
+    "react-dom": "^16.6.3"
   },
   "browserslist": [
     "last 2 versions",


### PR DESCRIPTION
We don't need both underscore and lodash. Lodash is preferred, so I've replaced underscore methods with lodash equivalents.

This PR, when merged, will close #38.